### PR TITLE
fix invalid conflict package config error at wxwidgets

### DIFF
--- a/recipes-extended/wxwidgets/wxwidgets_3.2.0.bbappend
+++ b/recipes-extended/wxwidgets/wxwidgets_3.2.0.bbappend
@@ -1,2 +1,4 @@
-PACKAGECONFIG:append = " gstreamer webkit"
-
+PACKAGECONFIG:append = " \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', d.getVar('GTK3DISTROFEATURES'), 'gstreamer', '', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', d.getVar('GTK3DISTROFEATURES'), 'webkit', '', d)} \
+"


### PR DESCRIPTION
fix invalid conflict package config error at wxwidgets


```
ERROR: .../meta-variscite-sdk/recipes-extended/wxwidgets/wxwidgets_3.2.0.bb: wxwidgets: PACKAGECONFIG[gtk] Invalid conflict package config 'no_gui' specified.
ERROR: .../meta-variscite-sdk/recipes-extended/wxwidgets/wxwidgets_3.2.0.bb: wxwidgets: PACKAGECONFIG[libsecret] Invalid conflict package config 'no_gui' specified.
ERROR: .../meta-variscite-sdk/recipes-extended/wxwidgets/wxwidgets_3.2.0.bb: wxwidgets: PACKAGECONFIG[qt] Invalid conflict package config 'no_gui' specified.
ERROR: .../meta-variscite-sdk/recipes-extended/wxwidgets/wxwidgets_3.2.0.bb: wxwidgets: PACKAGECONFIG[webkit] Invalid conflict package config 'no_gui' specified.
ERROR: .../meta-variscite-sdk/recipes-extended/wxwidgets/wxwidgets_3.2.0.bb: wxwidgets: PACKAGECONFIG[webkit] Conflict package config 'no_gui' set in PACKAGECONFIG.
ERROR: Parsing halted due to errors, see error messages above
```

1. Use `fsl-framebuffer`


```
MACHINE=imx6ul-var-dart DISTRO=fslc-framebuffer . setup-environment build_fb
```

Note: change to `MACHINE=imx6ul-var-dart` at the above.

2.

`bitbake -f core-image-minimal
`



