### PR TITLE
packagegroup-var-ml: mx93: add tf ethosu delegate and eiq examples

### DIFF
--- a/recipes-fsl/packagegroup/packagegroup-var-ml.bb
+++ b/recipes-fsl/packagegroup/packagegroup-var-ml.bb
@@ -39,6 +39,8 @@ ETHOS_U_PKGS = ""
 ETHOS_U_PKGS:mx93-nxp-bsp = " \
     ethos-u-vela \
     ethos-u-driver-stack \
+    tensorflow-lite-ethosu-delegate \
+    eiq-examples \
 "
 
 RDEPENDS:${PN} = " \


### PR DESCRIPTION
See:
- https://github.com/nxp-imx/meta-imx/commit/4bc3c79e14b7bd0f367c73e8320f93d58269d3ab
- https://github.com/nxp-imx/meta-imx/commit/4bc3c79e14b7bd0f367c73e8320f93d58269d3ab

The delegate is required for running models with TFLite inference engine using the Ethos-U Delegate (offload the “ethos-u” operator to Ethos-U NPU):

# cd /usr/bin/tensorflow-lite-2.11.1/examples
#  ./label_image -m ../../ethosu/examples/output/mobilenet_v1_1.0_224_quant_vela.tflite --external_delegate_path=/usr/lib/libethosu_delegate.so